### PR TITLE
Improve number format

### DIFF
--- a/src/simulator/landingPage/comparison/Comparison.tsx
+++ b/src/simulator/landingPage/comparison/Comparison.tsx
@@ -160,7 +160,7 @@ export function Comparison() {
                   onChange={event => setTotalDistanceKm(event)}
                 />
                 <div className="flex flex-row gap-1">
-                  <div>{totalDistanceKm}</div>
+                  <div>{`${totalDistanceKm.toLocaleString()}`}</div>
                   <span>km</span>
                 </div>
               </div>


### PR DESCRIPTION
Hello, this PR just put `,` in the total distance km label. It improves the readability of the number. Thanks for publishing the awesome project! 🙂 

**Before**

<img width="921" alt="Screenshot 2023-01-01 at 1 28 38" src="https://user-images.githubusercontent.com/1425259/210149928-1d1c9fd3-a22e-40a7-99d0-a6d4eb175a0e.png">

**After**

<img width="937" alt="Screenshot 2023-01-01 at 1 28 24" src="https://user-images.githubusercontent.com/1425259/210149929-8900316d-901c-4022-8ee8-aa2e2699fb4d.png">